### PR TITLE
Allow partials to be used with raises operators

### DIFF
--- a/grappa/operators/raises.py
+++ b/grappa/operators/raises.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import inspect
 from ..operator import Operator
 
 

--- a/grappa/operators/raises.py
+++ b/grappa/operators/raises.py
@@ -57,7 +57,7 @@ class RaisesOperator(Operator):
     )
 
     def match(self, fn, *errors):
-        if not any([inspect.isfunction(fn) or inspect.ismethod(fn)]):
+        if not callable(fn):
             return False, ['subject must be a function or method']
 
         try:

--- a/tests/operators/raises_test.py
+++ b/tests/operators/raises_test.py
@@ -1,12 +1,20 @@
 import pytest
+from functools import partial
 
 
 def test_raises(should):
     def error():
         raise AssertionError('foo')
 
+    def error_with_params(foo_param):
+        raise AssertionError(foo_param)
+
     error | should.raise_error(AssertionError)
     error | should.do_not.raise_error(NotImplementedError)
+
+    partial(error_with_params, "Foobar") | should.raise_error(AssertionError)
+    partial(error_with_params, "Foobar") | should.to_not\
+        .raise_error(NotImplementedError)
 
     with pytest.raises(AssertionError):
         error | should.raise_error(NotImplementedError)


### PR DESCRIPTION
Changes the raises operator to use callable
Addes unit tests for partial function (functools.partial)
fixes #37 