### PR TITLE
Relax runtime dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-colorama==0.3.9
-six==1.11.0
+colorama>=0.3.9,<2
+six~=1.11


### PR DESCRIPTION
This is a fix for #49.

Because colorama is still a prerelease, a compatible release clause does not really work. Let's hope they don't break compatibility for 1.0. :smile: 