### PR TITLE
Once negated a sentence must not be un-negated

### DIFF
--- a/grappa/operators/attributes.py
+++ b/grappa/operators/attributes.py
@@ -13,7 +13,7 @@ def be(ctx):
     Semantic attributes providing chainable declarative DSL
     for assertions.
     """
-    ctx.negate = False
+    pass
 
 
 @attribute(operators=(


### PR DESCRIPTION
Before, the following expectations pass, because `be` un-negated the previous negation.
```
expect(True).not_to.be.true
```

Now, it fails.