### PR TITLE
Allow usage of any subject attribute renderer messages

### DIFF
--- a/grappa/reporters/base.py
+++ b/grappa/reporters/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import re
 import six
 from ..empty import empty
 
@@ -72,6 +73,11 @@ class BaseReporter(object):
 
         if '{length}' in tmpl:
             placeholders['length'] = self.safe_length(value)
+
+        custom_properties = re.findall('{%(.*?)%}', tmpl)
+
+        for custom_property in custom_properties:
+            placeholders['%' + custom_property + '%'] = getattr(value, custom_property, 0)
 
         return tmpl.format(**placeholders)
 


### PR DESCRIPTION
I propose this because I'm doing custom operator to wrap [unit test mocks assertions](https://docs.python.org/3.5/library/unittest.mock.html).

And I wanted to display the number of [call count](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.call_count) which is an attribute of MagicMock object.
```
    expected_message = Operator.Dsl.Message(
        'a mock that has been called {value} times',
        'a mock that has not been called {value} times',
    )
    subject_message = Operator.Dsl.Message(
        'a mock that has been called {%call_count%} times',
        'a mock that has not been called {%call_count%} times',
    )
```

When `{value}` is used in `subject_message` it prints the `repr()` value
```
<MagicMock name='get_service_state.name' id='1897037976184'>
```