### PR TITLE
RST update: fixes #57, splitted operator page, added mock operators, other doc refactor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ lightweight assertion library for Python_ that aims to make testing more product
 It also comes with a detailed, human-friendly `error reporting`_ system that aims to reduce friction,
 provide better feedback and improve human speed and agility while identifying and fixing errors.
 
-To get started, take a look to the `showcase`_ code, `tutorial`_, available `plugins`_ and `operators documentation`_.
+To get started, take a look to the `showcase`_ code, `getting started`_, available `plugins`_ and operators documentation (`accessors`_, `attributes`_, `matchers`_).
 
 For HTTP protocol assertions, see `grappa-http`_.
 
@@ -33,7 +33,7 @@ Showcase
 --------
 
 A small example demonstrating some `grappa` features.
-See `documentation`_ and `tutorial`_ for more examples.
+See `documentation`_ and `getting started`_ for more examples.
 
 .. code-block:: python
 
@@ -105,26 +105,11 @@ Let's see how the error report looks like in ``grappa`` running in ``pytest``.
 
 See `error reporting`_ documentation for more details about how ``grappa`` error report system works.
 
-.. code-block:: python
+.. code-block:: bash
 
     ======================================================================
     FAIL: tests.should_test.test_grappa_assert
     ======================================================================
-    Traceback (most recent call last):
-    File ".pyenv/versions/3.6.0/lib/python3.6/site-packages/nose/case.py", line 198, in runTest
-    self.test(*self.arg)
-    File "grappa/tests/should_test.py", line 16, in test_grappa_assert
-    x | should.be.have.length.of(4)
-    File "grappa/grappa/test.py", line 248, in __ror__
-    return self.__overload__(value)
-    File "grappa/grappa/test.py", line 236, in __overload__
-    return self.__call__(subject, overload=True)
-    File "grappa/grappa/test.py", line 108, in __call__
-    return self._trigger() if overload else Test(subject)
-    File "grappa/grappa/test.py", line 153, in _trigger
-    raise err
-    AssertionError: Oops! Something went wrong!
-
     The following assertion was not satisfied
       subject "[1, 2, 3]" should be have length of "4"
 
@@ -167,14 +152,6 @@ See `error reporting`_ documentation for more details about how ``grappa`` error
     21|      False | should.be.false | should.be.equal.to(False)
     22|      False | should.be.false | should.not_be.equal.to(True)
 
-Demo
-----
-
-.. image:: https://asciinema.org/a/d6yd2475m41thdku7d3ntkeir.png
-   :width: 900
-   :alt: showcase
-   :align: center
-   :target: https://asciinema.org/a/d6yd2475m41thdku7d3ntkeir?autoplay=1&speed=3&size=small
 
 Why grappa?
 -----------
@@ -206,7 +183,7 @@ Features
 -  Behavior-oriented expressive fluent API.
 -  Built-in assertion DSL with English lexicon and semantics.
 -  Supports both ``expect`` and ``should`` assertion styles.
--  Full-featured built-in `assertion operators`_.
+-  Full-featured built-in `accessors`_, `attributes`_ and `matchers`_ operators.
 -  Human-friendly and detailed `error reporting`_.
 -  Built-in expectations difference comparison between subject and expected values.
 -  Extensible assertions supporting third-party `plugins`_.
@@ -236,12 +213,13 @@ Or install the latest sources from Github:
 
 .. _Python: http://python.org
 .. _`documentation`: http://grappa.readthedocs.io
-.. _`operators documentation`: http://grappa.readthedocs.io/en/latest/operators.html
-.. _`tutorial`: http://grappa.readthedocs.io/en/latest/tutorial.html
+.. _`accessors`: http://grappa.readthedocs.io/en/latest/accessors-operators.html
+.. _`attributes`: http://grappa.readthedocs.io/en/latest/attributes-operators.html
+.. _`matchers`: http://grappa.readthedocs.io/en/latest/matchers-operators.html
+.. _`getting started`: http://grappa.readthedocs.io/en/latest/getting-started.html
 .. _`plugins`: http://grappa.readthedocs.io/en/latest/plugins.html
-.. _`error reporting`: http://grappa.readthedocs.io/en/latest/errors.html
+.. _`error reporting`: http://grappa.readthedocs.io/en/latest/error-reporting.html
 .. _`assertion styles`: http://grappa.readthedocs.io/en/latest/style.html
-.. _`assertion operators`: http://grappa.readthedocs.io/en/latest/operators.html
 .. _`grappa-http`: https://github.com/grappa-py/http
 
 .. |Build Status| image:: https://travis-ci.org/grappa-py/grappa.svg?branch=master

--- a/docs/accessors-operators.rst
+++ b/docs/accessors-operators.rst
@@ -1,0 +1,195 @@
+Accessors Operators
+===================
+
+These operators do not accept expectation arguments but performs assertion logic.
+
+Example operators: none_, true_, false_, empty_, callable_ ...
+
+
+true
+----
+
+Asserts if a given subject is `True` value.
+
+=======================  ========================
+ **Related operators**   false_
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.be.true
+
+.. code-block:: python
+
+    'foo' | expect.to.be.true
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foo' | should.not_be.true
+
+.. code-block:: python
+
+    'foo' | expect.to_not.be.true
+
+
+false
+-----
+
+Asserts if a given subject is `False` value.
+
+=======================  ========================
+ **Related operators**   true_
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.be.false
+
+.. code-block:: python
+
+    'foo' | expect.to.be.false
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foo' | should.not_be.false
+
+.. code-block:: python
+
+    'foo' | expect.to_not.be.false
+
+
+callable
+--------
+
+Asserts if a given subject is a callable type or an object that
+implements ``__call__()`` magic method.
+
+=======================  ========================
+ **Related operators**   implements_
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    (lambda x: x) | should.be.callable
+
+.. code-block:: python
+
+    (lambda x: x) | expect.to.be.callable
+
+**Negation form**:
+
+.. code-block:: python
+
+    None | should.not_be.callable
+
+.. code-block:: python
+
+    None | expect.to_not.be.callable
+
+
+empty
+-----
+
+Asserts if a given subject is an empty object.
+
+A subject is considered empty if it's ``None``, ``0`` or ``len(subject)``
+is equals to ``0``.
+
+=======================  ========================
+ **Related operators**   present_ none_
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    [] | should.be.empty
+
+.. code-block:: python
+
+    tuple() | expect.to.be.empty
+
+**Negation form**:
+
+.. code-block:: python
+
+    [1, 2, 3] | should.not_be.empty
+
+.. code-block:: python
+
+    (1, 2, 3) | expect.to_not.be.empty
+
+
+none
+----
+
+Asserts if a given subject is ``None``.
+
+=======================  ========================
+ **Related operators**   present_ empty_
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    None | should.be.none
+
+.. code-block:: python
+
+    None | expect.to.be.none
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foo' | should.not_be.none
+
+.. code-block:: python
+
+    'foo' | expect.to_not.be.none
+
+
+exists
+------
+present
+-------
+
+Asserts if a given subject is not ``None`` or a negative value
+if evaluated via logical unary operator.
+
+This operator is the opposite of empty_.
+
+=======================  ========================
+ **Related operators**   none_ empty_
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.be.present
+
+.. code-block:: python
+
+    'foo' | expect.to.be.present
+
+**Negation form**:
+
+.. code-block:: python
+
+    '' | should.not_be.present
+
+.. code-block:: python
+
+    False | expect.to_not.be.present

--- a/docs/accessors-operators.rst
+++ b/docs/accessors-operators.rst
@@ -193,3 +193,6 @@ This operator is the opposite of empty_.
 .. code-block:: python
 
     False | expect.to_not.be.present
+
+
+.. _`implements`: http://grappa.readthedocs.io/en/latest/matchers-operators.html#implements

--- a/docs/accessors-operators.rst
+++ b/docs/accessors-operators.rst
@@ -15,25 +15,15 @@ Asserts if a given subject is `True` value.
  **Related operators**   false_
 =======================  ========================
 
-**Assertion form**:
-
 .. code-block:: python
 
     'foo' | should.be.true
-
-.. code-block:: python
-
-    'foo' | expect.to.be.true
-
-**Negation form**:
-
-.. code-block:: python
-
     'foo' | should.not_be.true
 
 .. code-block:: python
 
-    'foo' | expect.to_not.be.true
+    expect('foo').to.be.true
+    expect('foo').to_not.be.true
 
 
 false
@@ -45,25 +35,15 @@ Asserts if a given subject is `False` value.
  **Related operators**   true_
 =======================  ========================
 
-**Assertion form**:
-
 .. code-block:: python
 
     'foo' | should.be.false
-
-.. code-block:: python
-
-    'foo' | expect.to.be.false
-
-**Negation form**:
-
-.. code-block:: python
-
     'foo' | should.not_be.false
 
 .. code-block:: python
 
-    'foo' | expect.to_not.be.false
+    expect('foo').to.be.false
+    expect('foo').to_not.be.false
 
 
 callable
@@ -76,25 +56,15 @@ implements ``__call__()`` magic method.
  **Related operators**   implements_
 =======================  ========================
 
-**Assertion form**:
-
 .. code-block:: python
 
     (lambda x: x) | should.be.callable
-
-.. code-block:: python
-
-    (lambda x: x) | expect.to.be.callable
-
-**Negation form**:
-
-.. code-block:: python
-
     None | should.not_be.callable
 
 .. code-block:: python
 
-    None | expect.to_not.be.callable
+    expect(lambda x: x).to.be.callable
+    expect(None).to_not.be.callable
 
 
 empty
@@ -109,25 +79,15 @@ is equals to ``0``.
  **Related operators**   present_ none_
 =======================  ========================
 
-**Assertion form**:
-
 .. code-block:: python
 
     [] | should.be.empty
-
-.. code-block:: python
-
-    tuple() | expect.to.be.empty
-
-**Negation form**:
-
-.. code-block:: python
-
     [1, 2, 3] | should.not_be.empty
 
 .. code-block:: python
 
-    (1, 2, 3) | expect.to_not.be.empty
+    expect(tuple()).to.be.empty
+    expect((1, 2, 3)).to_not.be.empty   
 
 
 none
@@ -139,25 +99,15 @@ Asserts if a given subject is ``None``.
  **Related operators**   present_ empty_
 =======================  ========================
 
-**Assertion form**:
-
 .. code-block:: python
 
     None | should.be.none
-
-.. code-block:: python
-
-    None | expect.to.be.none
-
-**Negation form**:
-
-.. code-block:: python
-
     'foo' | should.not_be.none
 
 .. code-block:: python
 
-    'foo' | expect.to_not.be.none
+    expect(None).to.be.none
+    expect('foo').to_not.be.none
 
 
 exists
@@ -174,25 +124,15 @@ This operator is the opposite of empty_.
  **Related operators**   none_ empty_
 =======================  ========================
 
-**Assertion form**:
-
 .. code-block:: python
 
     'foo' | should.be.present
-
-.. code-block:: python
-
-    'foo' | expect.to.be.present
-
-**Negation form**:
-
-.. code-block:: python
-
     '' | should.not_be.present
 
 .. code-block:: python
 
-    False | expect.to_not.be.present
+    expect('foo').to.be.present
+    expect(False).to_not.be.present
 
 
 .. _`implements`: http://grappa.readthedocs.io/en/latest/matchers-operators.html#implements

--- a/docs/attributes-operators.rst
+++ b/docs/attributes-operators.rst
@@ -46,8 +46,6 @@ Typically, you will use them implicitly in order to semantically describe your a
  **Resets context**      no
 =======================  ========================
 
-**Examples**:
-
 .. code-block:: python
 
     'foo' | should.be.equal.to('bar')
@@ -58,11 +56,11 @@ Typically, you will use them implicitly in order to semantically describe your a
 
 .. code-block:: python
 
-    'foo' | expect.to.equal.to('bar')
-    'foo' | expect.to.have.length.of(3)
+    expect('foo').to.equal.to('bar')
+    expect('foo').to.have.length.of(3)
 
-    {'foo': 'bar'} | expect.to.have.key('foo').which.expect.to.be.equal('bar')
-    {'foo': 'bar'} | expect.to.have.key('foo').which.expect.to.have.length.of(3)
+    expect({'foo': 'bar'}).to.have.key('foo').which.expect.to.be.equal('bar')
+    expect({'foo': 'bar'}).to.have.key('foo').which.expect.to.have.length.of(3)
 
 
 Negation
@@ -111,8 +109,6 @@ Typically, you will use them implicitly in order to semantically describe your a
  **Resets context**      no
 =======================  ========================
 
-**Examples**:
-
 .. code-block:: python
 
     'foo' | should.not_be.equal.to('bar')
@@ -120,5 +116,5 @@ Typically, you will use them implicitly in order to semantically describe your a
 
 .. code-block:: python
 
-    'foo' | expect.to_not.equal.to('bar')
-    'foo' | expect.to.not_have.length.of(3)
+    expect('foo').to_not.equal.to('bar')
+    expect('foo').to.not_have.length.of(3)

--- a/docs/attributes-operators.rst
+++ b/docs/attributes-operators.rst
@@ -1,0 +1,124 @@
+Attributes Operators
+====================
+
+These operators provides assertion/negation logic.
+
+Example operators: to_, be_ not_be_, which_ ...
+
+
+Assertion
+---------
+
+be
+^^
+to
+^^
+has
+^^^
+have
+^^^^
+do
+^^
+include
+^^^^^^^
+satisfy
+^^^^^^^
+satisfies
+^^^^^^^^^
+_is
+^^^
+which
+^^^^^
+that
+^^^^
+that_is
+^^^^^^^
+which_is
+^^^^^^^^
+
+Semantic chainable attributes that defines non-negative assertions.
+
+Typically, you will use them implicitly in order to semantically describe your assertions.
+
+=======================  ========================
+ **Assertion mode**      positive
+-----------------------  ------------------------
+ **Resets context**      no
+=======================  ========================
+
+**Examples**:
+
+.. code-block:: python
+
+    'foo' | should.be.equal.to('bar')
+    'foo' | should.have.length.of(3)
+
+    {'foo': 'bar'} | should.have.key('foo').which.should.be.equal.to('bar')
+    {'foo': 'bar'} | should.have.key('foo').that.should.have.length.of(3)
+
+.. code-block:: python
+
+    'foo' | expect.to.equal.to('bar')
+    'foo' | expect.to.have.length.of(3)
+
+    {'foo': 'bar'} | expect.to.have.key('foo').which.expect.to.be.equal('bar')
+    {'foo': 'bar'} | expect.to.have.key('foo').which.expect.to.have.length.of(3)
+
+
+Negation
+--------
+
+not_be
+^^^^^^
+not_present
+^^^^^^^^^^^
+not_to
+^^^^^^
+to_not
+^^^^^^
+does_not
+^^^^^^^^
+do_not
+^^^^^^
+dont
+^^^^
+have_not
+^^^^^^^^
+not_have
+^^^^^^^^
+has_not
+^^^^^^^
+not_has
+^^^^^^^
+that_not
+^^^^^^^^
+which_not
+^^^^^^^^^
+is_not
+^^^^^^
+_not
+^^^^
+not_satisfy
+^^^^^^^^^^^
+
+Semantic chainable attributes that defines negative assertions.
+
+Typically, you will use them implicitly in order to semantically describe your assertions.
+
+=======================  ========================
+ **Assertion mode**      negation
+-----------------------  ------------------------
+ **Resets context**      no
+=======================  ========================
+
+**Examples**:
+
+.. code-block:: python
+
+    'foo' | should.not_be.equal.to('bar')
+    'foo' | should.have_not.length.of(3)
+
+.. code-block:: python
+
+    'foo' | expect.to_not.equal.to('bar')
+    'foo' | expect.to.not_have.length.of(3)

--- a/docs/composition.rst
+++ b/docs/composition.rst
@@ -14,9 +14,6 @@ Use ``|`` operator for composing assertions that matches the following condition
 - Assertions that DO tests the same subject.
 - Assertions that uses operators that DOES NOT yield a new test subject.
 
-Example
-^^^^^^^
-
 .. code-block:: python
 
     'foo' | should.have.length.of(3) | should.contain('o')
@@ -32,9 +29,6 @@ Use ``>`` operator for composing assertions that matches the following condition
 - A typical `AND` logical composition.
 - Assertions that DOES NOT test the same subject.
 - Assertions that uses operators that YIELDS a new test subject in the assertion chain.
-
-Example
-^^^^^^^
 
 .. code-block:: python
 

--- a/docs/error-reporting.rst
+++ b/docs/error-reporting.rst
@@ -130,4 +130,4 @@ You can include arbitrary custom messages that would be included in the error re
 
     'foo' | should.be.equal('bar', msg='additional error message')
 
-    'foo' | expect.to.equal('bar', msg='additional error message')
+    expect('foo').to.equal('bar', msg='additional error message')

--- a/docs/error-reporting.rst
+++ b/docs/error-reporting.rst
@@ -5,7 +5,7 @@ Feedback while testing is key. Seeing errors in your tests is not a nice thing
 because informs you something is wrong with your code.
 This can even introduce frustration and FUD to developers.
 
-``grappa`` comes with a built-in detailed and **human friendly** error reporting
+``grappa`` provides a detailed and **human friendly** behavior-oriented error reporting
 to intuitively and effectively help the developer answer the following questions:
 
 - what test failed
@@ -16,8 +16,6 @@ to intuitively and effectively help the developer answer the following questions
 - how to solve the error
 - additional information about the how the assertion works
 
-``grappa`` provides intuitive error reporting for human friendly consumption,
-which includes a behavior-oriented
 
 Standard errors vs grappa errors
 --------------------------------

--- a/docs/error-reporting.rst
+++ b/docs/error-reporting.rst
@@ -1,18 +1,12 @@
-Errors
-======
-
-``grappa`` comes with a built-in detailed, human-friendly `error reporting`_ system
-that aims to reduce friction and improve human agility while testing and fixing software.
-
 Error Reporting
----------------
+===============
 
 Feedback while testing is key. Seeing errors in your tests is not a nice thing
 because informs you something is wrong with your code.
 This can even introduce frustration and FUD to developers.
 
-``grappa`` tries to mitigate this by providing a human friendly error reporting
-that informs the developer in an intuitive and more effective the following questions:
+``grappa`` comes with a built-in detailed and **human friendly** error reporting
+to intuitively and effectively help the developer answer the following questions:
 
 - what test failed
 - what are the reasons of the failure

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -125,7 +125,7 @@ with some additional properties that provides context data from ``grappa`` for f
 Additional error properties:
 
 - **__grappa__** ``bool`` - Error flag that indicates the error was originated by ``grappa``.
-- **error** ``Exception`` - Original exception error, if any.
+- **__cause__** ``Exception`` - Original exception error, if any. Python >= 3.5 uses this property to enhance traceback.
 - **context** ``grappa.Context`` - Current test ``grappa`` context instance. Only for low-level debugging.
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -13,9 +13,8 @@ Can I extend ``grappa`` with other assertion operators?
 
 Of course you can. ``grappa`` is an extensible modular testing library.
 
-See `creating your custom operators` documentation section.
+See `creating your custom operator`_ documentation section.
 
-.. _`creating your custom operator`: http://grappa.readthedocs.io/en/latest/plugins.html#creating-operators
 
 Why use ``grappa`` instead of traditional Python assertions?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,3 +30,6 @@ It certainly is, but comes with several benefits that you won't have without it,
 - ``grappa`` does type validation under the hood to ensure your providing a valid type.
 - ``grappa`` is an extensible assertion layer that can be used in a lot of ways, such as for HTTP protocol testing.
 - First-class support for Python data structures assertions and access.
+
+
+.. _`creating your custom operator`: http://grappa.readthedocs.io/en/latest/plugins.html#creating-operators

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,10 +1,20 @@
-Tutorial
-========
+Getting started
+===============
 
-Installing grappa
------------------
+Installation
+------------
 
-Please, see installation_ section.
+Using ``pip`` package manager:
+
+.. code-block:: bash
+
+    pip install --upgrade grappa
+
+Or install the latest sources from Github:
+
+.. code-block:: bash
+
+    pip install -e git+git://github.com/grappa-py/grappa.git#egg=grappa
 
 
 Importing grappa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,10 +5,12 @@ Contents
    :maxdepth: 2
 
    intro
-   tutorial
+   getting-started
    style
-   errors
-   operators
+   error-reporting
+   attributes-operators
+   accessors-operators
+   matchers-operators
    composition
    configuration
    plugins

--- a/docs/matchers-operators.rst
+++ b/docs/matchers-operators.rst
@@ -916,7 +916,7 @@ arguments
  **Chained aliases**     ``to`` ``that`` ``are`` ``instance`` ``of``
 -----------------------  ------------------------
  **Related operators**   matches_
- ----------------------  ------------------------
+-----------------------  ------------------------
  **Yields subject**      Message of the exception, if present or joined exception arguments.
 -----------------------  ------------------------
  **Optional keywords**   ``msg: str``
@@ -929,12 +929,16 @@ arguments
     fn | should.raise_error()
     fn | should.raise_error(ValueError)
     fn | should.raise_error(AttributeError, ValueError)
+    fn | should.raise_error(ValueError) > should.equal('File not found')
+    fn | should.raise_error(ValueError) > should.contain('not found')
 
 .. code-block:: python
 
     fn | expect.to.raise_error()
     fn | expect.to.raise_error(ValueError)
     fn | expect.to.raise_error(AttributeError, ValueError)
+    fn | expect.to.raise_error(ValueError) > should.equal('File not found')
+    fn | expect.to.raise_error(ValueError) > should.contain('not found')
 
 **Negation form**:
 

--- a/docs/matchers-operators.rst
+++ b/docs/matchers-operators.rst
@@ -994,3 +994,110 @@ Asserts if a given subject is valid when passed to a predicate function.
 
     'foo' | expect.to_not.pass_test(lambda x: len(x) > 3)
     [1, 2, 3] | expect.to_not.pass_function(lambda x: 5 in x)
+
+Mocks
+-----
+
+Required implementation of a mock subject is based on `unittest.mock.Mock`_ class.
+
+To be compatible with ``grappa``, mocks must only implement:
+
+- **called**: a boolean property which indicates whether the mock has been called, or not.
+- **call_count**: an integer property which indicates the number of times the mock has been called.
+- **assert_called_with(*args, **kwargs)**: a function which raises an ``AssertionError`` when the mock has not been called with given arguments.
+- **assert_called_once_with(*args, **kwargs)**: a function which raises an ``AssertionError`` when the mock has not been called with given arguments.
+
+
+.. warning::
+
+    Mock matchers are not (yet) compatible with piping (|) assertion style.
+
+
+been_called
+^^^^^^^^^^^
+
+Asserts if a given mock subject have been called at least once.
+
+=======================  ========================
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+.. code-block:: python
+
+    expect(mock).to.have.been_called
+
+    expect(mock).to.have_not.been_called
+
+
+been_called_once
+^^^^^^^^^^^^^^^^
+
+Asserts if a given mock subject have been called only once.
+
+=======================  ========================
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+.. code-block:: python
+
+    expect(mock).to.have.been_called_once
+
+    expect(mock).to.have_not.been_called_once
+
+
+been_called_times
+^^^^^^^^^^^^^^^^^
+
+Asserts if a given mock subject have been called n times.
+
+=======================  ========================
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    expect(mock).to.have.been_called_times(0)
+
+    expect(mock).to.have_not.been_called_times(3)
+
+
+
+been_called_with
+^^^^^^^^^^^^^^^^
+
+Asserts if a given mock subject have been called at least once
+with specified arguments.
+
+=======================  ========================
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+.. code-block:: python
+
+    expect(mock).to.have.been_called_with('foo')
+    expect(mock).to.have.been_called_with('foo', True, 150)
+
+    expect(mock).to.have_not.been_called_with('bar', False)
+
+
+been_called_once_with
+^^^^^^^^^^^^^^^^^^^^^
+
+Asserts if a given mock subject have been called only once
+with specified arguments.
+
+=======================  ========================
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+.. code-block:: python
+
+    expect(mock).to.have.been_called_once_with('foo')
+    expect(mock).to.have.been_called_once_with('foo', True, 150)
+
+    expect(mock).to.have_not.been_called_once_with('bar', False)
+
+
+.. _`unittest.mock.Mock`: https://docs.python.org/3/library/unittest.mock.html#the-mock-class

--- a/docs/matchers-operators.rst
+++ b/docs/matchers-operators.rst
@@ -5,12 +5,12 @@ These operators does accept expectation arguments and therefore are callable.
 
 Example operators: equal_, within_, start_with_, match_, type_ ...
 
-Matchers
---------
+
+Generic
+-------
 
 equal
 ^^^^^
-
 same
 ^^^^
 
@@ -57,10 +57,8 @@ Uses ``==`` built-in binary operator for the comparison.
 
 contain
 ^^^^^^^
-
 contains
 ^^^^^^^^
-
 includes
 ^^^^^^^^
 
@@ -103,9 +101,203 @@ Asserts if a given value or values can be found in a another object.
     ['foo', 'bar'] | expect.to_not.contain('baz')
 
 
+length
+^^^^^^
+size
+^^^^
+
+Asserts that a given object has exact length.
+
+=======================  ========================
+ **Chained aliases**     ``of`` ``equal`` ``to``
+-----------------------  ------------------------
+ **Related operators**   matches_
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.have.length(3)
+    [1, 2, 3] | should.have.length.of(3)
+    iter([1, 2, 3]) | should.have.length.equal.to(3)
+
+.. code-block:: python
+
+    'foo' | expect.to.have.length(3)
+    [1, 2, 3] | expect.to.have.length.of(3)
+    iter([1, 2, 3]) | expect.to.have.length.equal.to(3)
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foobar' | should.not_have.length(3)
+    [1, 2, 3, 4] | should.not_have.length.of(3)
+    iter([1, 2, 3, 4]) | should.not_have.length.equal.to(3)
+
+.. code-block:: python
+
+    'foobar' | expect.to_not.have.length(3)
+    [1, 2, 3, 4] | expect.to_not.have.length.of(3)
+    iter([1, 2, 3, 4]) | expect.to_not.have.length.equal.to(3)
+
+
+start_with
+^^^^^^^^^^
+starts_with
+^^^^^^^^^^^
+
+Asserts if a given value starts with a specific items.
+
+=======================  ========================
+ **Chained aliases**     ``by`` ``word`` ``number`` ``numbers`` ``item`` ``items`` ``value`` ``char`` ``letter`` ``character``
+-----------------------  ------------------------
+ **Related operators**   ends_with_
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.start_with('f')
+    'foo' | should.start_with('fo')
+    [1, 2, 3] | should.start_with.number(1)
+    iter([1, 2, 3]) | should.start_with.numbers(1, 2)
+    OrderedDict([('foo', 0), ('bar', 1)]) | should.start_with.item('foo')
+
+.. code-block:: python
+
+    'foo' | expect.to.start_with('f')
+    'foo' | expect.to.start_with('fo')
+    [1, 2, 3] | expect.to.start_with.number(1)
+    iter([1, 2, 3]) | expect.to.start_with.numbers(1, 2)
+    OrderedDict([('foo', 0), ('bar', 1)]) | expect.to.start_with('foo')
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foo' | should.do_not.start_with('o')
+    'foo' | should.do_not.start_with('o')
+    [1, 2, 3] | should.do_not.start_with(2)
+    iter([1, 2, 3]) | should.do_not.start_with.numbers(3, 4)
+    OrderedDict([('foo', 0), ('bar', 1)]) | should.start_with('bar')
+
+.. code-block:: python
+
+    'foo' | expect.to_not.start_with('f')
+    'foo' | expect.to_not.start_with('fo')
+    [1, 2, 3] | expect.to_not.start_with.number(1)
+    iter([1, 2, 3]) | expect.to_not.start_with.numbers(1, 2)
+    OrderedDict([('foo', 0), ('bar', 1)]) | expect.to_not.start_with('foo')
+
+
+end_with
+^^^^^^^^
+ends_with
+^^^^^^^^^
+
+Asserts if a given value ends with a specific items.
+
+=======================  ========================
+ **Chained aliases**     ``by`` ``word`` ``number`` ``numbers`` ``item`` ``items`` ``value`` ``char`` ``letter`` ``character``
+-----------------------  ------------------------
+ **Related operators**   ends_with_
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.ends_with('o')
+    'foo' | should.ends_with('oo')
+    [1, 2, 3] | should.ends_with.number(3)
+    iter([1, 2, 3]) | should.ends_with.numbers(2, 3)
+    OrderedDict([('foo', 0), ('bar', 1)]) | should.ends_with.item('bar')
+
+.. code-block:: python
+
+    'foo' | expect.to.ends_with('o')
+    'foo' | expect.to.ends_with('oo')
+    [1, 2, 3] | expect.to.ends_with.number(3)
+    iter([1, 2, 3]) | expect.to.ends_with.numbers(2, 3)
+    OrderedDict([('foo', 0), ('bar', 1)]) | expect.to.ends_with('bar')
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foo' | should.do_not.ends_with('f')
+    'foo' | should.do_not.ends_with('o')
+    [1, 2, 3] | should.do_not.ends_with(2)
+    iter([1, 2, 3]) | should.do_not.ends_with.numbers(3, 4)
+    OrderedDict([('foo', 0), ('bar', 1)]) | should.ends_with('foo')
+
+.. code-block:: python
+
+    'foo' | expect.to_not.ends_with('f')
+    'foo' | expect.to_not.ends_with('oo')
+    [1, 2, 3] | expect.to_not.ends_with.number(2)
+    iter([1, 2, 3]) | expect.to_not.ends_with.numbers(1, 2)
+    OrderedDict([('foo', 0), ('bar', 1)]) | expect.to_not.ends_with('foo')
+
+
+match
+^^^^^
+matches
+^^^^^^^
+
+Asserts if a given string matches a given regular expression.
+
+=======================  ========================
+ **Chained aliases**     ``value`` ``string`` ``expression``, ``token``, ``to``, ``regex``, ``regexp``, ``word``, ``phrase``
+-----------------------  ------------------------
+ **Related operators**   matches_
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'hello world' | should.match(r'Hello \w+')
+    'hello world' | should.match(r'hello [A-Z]+', re.I))
+    'hello world' | should.match.expression(r'hello [A-Z]+', re.I))
+
+.. code-block:: python
+
+    'hello world' | expect.to.match(r'Hello \w+')
+    'hello world' | expect.to.match(r'hello [A-Z]+', re.I))
+    'hello world' | expect.to.match.expression(r'hello [A-Z]+', re.I))
+
+**Negation form**:
+
+.. code-block:: python
+
+    'hello w0rld' | should.do_not.match(r'Hello \w+')
+    'hello w0rld' | should.do_not.match(r'hello [A-Z]+', re.I))
+    'hello world' | should.do_not.match.expression(r'hello [A-Z]+', re.I))
+
+.. code-block:: python
+
+    'hello w0rld' | expect.to_not.match(r'Hello \w+')
+    'hello w0rld' | expect.to_not.match(r'hello [A-Z]+', re.I))
+    'hello world' | expect.to_not.match.expression(r'hello [A-Z]+', re.I))
+
+
+Collections
+-----------
+
 key
 ^^^
-
 keys
 ^^^^
 
@@ -192,413 +384,6 @@ Asserts that a given iterable has an item in a specific index.
     [1, 2, 3] | expect.to_not.have.index(2)
     [1, 2, 3] | expect.to_not.have.index.at(1)
     [1, 2, 3] | expect.to_not.have.index.at(1).equal.to(2)
-
-length
-^^^^^^
-
-size
-^^^^
-
-Asserts that a given object has exact length.
-
-=======================  ========================
- **Chained aliases**     ``of`` ``equal`` ``to``
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'foo' | should.have.length(3)
-    [1, 2, 3] | should.have.length.of(3)
-    iter([1, 2, 3]) | should.have.length.equal.to(3)
-
-.. code-block:: python
-
-    'foo' | expect.to.have.length(3)
-    [1, 2, 3] | expect.to.have.length.of(3)
-    iter([1, 2, 3]) | expect.to.have.length.equal.to(3)
-
-**Negation form**:
-
-.. code-block:: python
-
-    'foobar' | should.not_have.length(3)
-    [1, 2, 3, 4] | should.not_have.length.of(3)
-    iter([1, 2, 3, 4]) | should.not_have.length.equal.to(3)
-
-.. code-block:: python
-
-    'foobar' | expect.to_not.have.length(3)
-    [1, 2, 3, 4] | expect.to_not.have.length.of(3)
-    iter([1, 2, 3, 4]) | expect.to_not.have.length.equal.to(3)
-
-
-match
-^^^^^
-
-matches
-^^^^^^^
-
-Asserts if a given string matches a given regular expression.
-
-=======================  ========================
- **Chained aliases**     ``value`` ``string`` ``expression``, ``token``, ``to``, ``regex``, ``regexp``, ``word``, ``phrase``
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'hello world' | should.match(r'Hello \w+')
-    'hello world' | should.match(r'hello [A-Z]+', re.I))
-    'hello world' | should.match.expression(r'hello [A-Z]+', re.I))
-
-.. code-block:: python
-
-    'hello world' | expect.to.match(r'Hello \w+')
-    'hello world' | expect.to.match(r'hello [A-Z]+', re.I))
-    'hello world' | expect.to.match.expression(r'hello [A-Z]+', re.I))
-
-**Negation form**:
-
-.. code-block:: python
-
-    'hello w0rld' | should.do_not.match(r'Hello \w+')
-    'hello w0rld' | should.do_not.match(r'hello [A-Z]+', re.I))
-    'hello world' | should.do_not.match.expression(r'hello [A-Z]+', re.I))
-
-.. code-block:: python
-
-    'hello w0rld' | expect.to_not.match(r'Hello \w+')
-    'hello w0rld' | expect.to_not.match(r'hello [A-Z]+', re.I))
-    'hello world' | expect.to_not.match.expression(r'hello [A-Z]+', re.I))
-
-pass_test
-^^^^^^^^^
-
-pass_function
-^^^^^^^^^^^^^
-
-Asserts if a given string matches a given regular expression.
-
-=======================  ========================
- **Chained aliases**     -
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'foo' | should.pass_test(lambda x: len(x) > 2)
-    [1, 2, 3] | should.pass_function(lambda x: 2 in x)
-
-.. code-block:: python
-
-    'foo' | expect.to.pass_test(lambda x: len(x) > 2)
-    [1, 2, 3] | expect.to.pass_function(lambda x: 2 in x)
-
-**Negation form**:
-
-.. code-block:: python
-
-    'foo' | should.do_not.pass_test(lambda x: len(x) > 3)
-    [1, 2, 3] | should.do_not.pass_function(lambda x: 5 in x)
-
-.. code-block:: python
-
-    'foo' | expect.to_not.pass_test(lambda x: len(x) > 3)
-    [1, 2, 3] | expect.to_not.pass_function(lambda x: 5 in x)
-
-
-Objects
--------
-
-a
-^
-an
-^^
-type
-^^^^
-types
-^^^^^
-instance
-^^^^^^^^
-
-Asserts if a given object satisfies a type.
-You can use both a type alias string or a ``type`` object.
-
-Supported type aliases:
-
-- string
-- int
-- integer
-- number
-- object
-- float
-- bool
-- boolean
-- complex
-- list
-- dict
-- dictionary
-- tuple
-- set
-- array
-- lambda
-- generator
-- asyncgenerator
-- class
-- method
-- module
-- function
-- coroutine
-- generatorfunction
-- generator function
-- coroutinefunction
-
-=======================  ========================
- **Chained aliases**     ``type`` ``types`` ``to`` ``of``, ``equal``
------------------------  ------------------------
- **Related operators**   equal_ matches_ implements_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    1 | should.be.an('int')
-    1 | should.be.an('number')
-    True | should.be.a('bool')
-    True | should.be.type(bool)
-    'foo' | should.be.a(str)
-    'foo' | should.be.a('string')
-    [1, 2, 3] | should.be.a('list')
-    [1, 2, 3] | should.have.type.of(list)
-    (1, 2, 3) | should.be.a('tuple')
-    (1, 2, 3) | should.have.type.of(tuple)
-    (lamdba x: x) | should.be.a('lambda')
-    'foo' | should.be.instance.of('string')
-    'foo' | expect.be.types('string', 'int')
-
-.. code-block:: python
-
-    1 | expect.to.be.an('int')
-    1 | expect.to.be.an('number')
-    True | expect.to.be.a('bool')
-    True | expect.to.be.type(bool)
-    'foo' | expect.to.be.a(str)
-    'foo' | expect.to.be.a('string')
-    [1, 2, 3] | expect.to.be.a('list')
-    [1, 2, 3] | expect.to.have.type.of(list)
-    (1, 2, 3) | expect.to.be.a('tuple')
-    (1, 2, 3) | expect.to.have.type.of(tuple)
-    (lamdba x: x) | expect.to.be.a('lambda')
-    'foo' | expect.to.be.instance.of('string')
-    'foo' | expect.to.be.types('string', 'int')
-
-**Negation form**:
-
-.. code-block:: python
-
-    1 | should.not_be.an('int')
-    1 | should.not_be.an('number')
-    True | should.not_be.a('bool')
-    True | should.not_be.type(bool)
-    'foo' | should.not_be.a(str)
-    'foo' | should.not_be.a('string')
-    [1, 2, 3] | should.not_be.a('list')
-    [1, 2, 3] | should.have_not.type.of(list)
-    (1, 2, 3) | should.not_be.a('tuple')
-    (1, 2, 3) | should.have_not.type.of(tuple)
-    (lamdba x: x) | should.not_be.a('lambda')
-    'foo' | should.not_to.be.instance.of('string')
-    'foo' | should.not_to.be.types('string', 'int')
-
-.. code-block:: python
-
-    1 | expect.to_not.be.an('int')
-    1 | expect.to_not.be.an('number')
-    True | expect.to_not.be.a('bool')
-    True | expect.to_not.be.type(bool)
-    'foo' | expect.to_not.be.a(str)
-    'foo' | expect.to_not.be.a('string')
-    [1, 2, 3] | expect.to_not.be.a('list')
-    [1, 2, 3] | expect.to_not.have.type.of(list)
-    (1, 2, 3) | expect.to_not.be.a('tuple')
-    (1, 2, 3) | expect.to_not.have.type.of(tuple)
-    (lamdba x: x) | expect.to_not.be.a('lambda')
-    'foo' | expect.to.not_to.be.instance.of('string')
-    'foo' | expect.to.not_to.be.types('string', 'int')
-
-
-property
-^^^^^^^^^
-properties
-^^^^^^^^^^
-attribute
-^^^^^^^^^
-attributes
-^^^^^^^^^^
-
-Asserts if a given object has property or properties.
-
-=======================  ========================
- **Chained aliases**     ``present`` ``equal`` ``to``
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Yields subject**      The attribute value, if present.
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-
-implements
-^^^^^^^^^^
-implement
-^^^^^^^^^
-interface
-^^^^^^^^^
-
-Asserts if a given object implements an interface of methods.
-
-=======================  ========================
- **Chained aliases**     ``interface`` ``method`` ``methods``
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    Foo() | should.implements('bar')
-    Foo() | should.implements.method('bar')
-    Foo() | should.implement.methods('bar', 'baz')
-    Foo() | should.implement.interface('bar', 'baz')
-    Foo() | should.satisfies.interface('bar', 'baz')
-
-.. code-block:: python
-
-    Foo() | expect.to.implement('bar')
-    Foo() | expect.to.implement.method('bar')
-    Foo() | expect.to.implement.methods('bar', 'baz')
-    Foo() | expect.to.implement.interface('bar', 'baz')
-    Foo() | expect.to.satisfy.interface('bar', 'baz')
-
-**Negation form**:
-
-.. code-block:: python
-
-    Foo() | should.do_not.implements('bar')
-    Foo() | should.do_not.implement.methods('bar', 'baz')
-    Foo() | should.do_not.implement.interface('bar', 'baz')
-    Foo() | should.do_not.satisfy.interface('bar', 'baz')
-
-.. code-block:: python
-
-    Foo() | expect.to_not.implement('bar')
-    Foo() | expect.to_not.implement.method('bar')
-    Foo() | expect.to_not.implement.methods('bar', 'baz')
-    Foo() | expect.to_not.implement.interface('bar', 'baz')
-    Foo() | expect.to_not.satisfy.interface('bar', 'baz')
-
-**Assertion form**:
-
-.. code-block:: python
-
-    Foo() | should.have.property('bar')
-    Foo() | should.have.properties('bar', 'baz')
-    Foo() | should.have.properties.present.equal.to('bar', 'baz')
-
-.. code-block:: python
-
-    Foo() | expect.to_not.have.property('bar')
-    Foo() | expect.to_not.have.properties('bar', 'baz')
-    Foo() | expect.to_not.have.properties.present.equal.to('bar', 'baz')
-
-**Negation form**:
-
-.. code-block:: python
-
-    Foo() | should.have_not.property('bar')
-    Foo() | should.have_not.properties('bar', 'baz')
-    Foo() | should.have_not.properties.present.equal.to('bar', 'baz')
-
-.. code-block:: python
-
-    Foo() | expect.to_not.have.property('bar')
-    Foo() | expect.to_not.have.properties('bar', 'baz')
-    Foo() | expect.to_not.have.properties.present.equal.to('bar', 'baz')
-
-
-Exceptions
-----------
-
-raises
-^^^^^^
-raise_error
-^^^^^^^^^^^
-raises_errors
-^^^^^^^^^^^^^
-
-Asserts if a given function raises an exception. The function must be a zero
-arity function (no arguments). If you need to pass arguments into your function
-you can use ``functools.partial`` to create a zero arity function with your
-arguments
-
-=======================  ========================
- **Chained aliases**     ``to`` ``that`` ``are`` ``instance`` ``of``
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    fn | should.raise_error()
-    fn | should.raise_error(ValueError)
-    fn | should.raise_error(AttributeError, ValueError)
-
-.. code-block:: python
-
-    fn | expect.to.raise_error()
-    fn | expect.to.raise_error(ValueError)
-    fn | expect.to.raise_error(AttributeError, ValueError)
-
-**Negation form**:
-
-.. code-block:: python
-
-    fn | should.do_not.raise_error()
-    fn | should.do_not.raise_error(ValueError)
-    fn | should.do_not.raise_error(AttributeError, ValueError)
-
-.. code-block:: python
-
-    fn | expect.to_not.raise_error()
-    fn | expect.to_not.raise_error(ValueError)
-    fn | expect.to_not.raise_error(AttributeError, ValueError)
 
 
 Numbers
@@ -885,22 +670,57 @@ Asserts that a number is within a range.
     5 | expect.to_not.be.between(2, 5)
     4.5 | expect.to_not.be.within(4, 5)
 
-Ranges
-------
 
-start_with
-^^^^^^^^^^
-startswith
-^^^^^^^^^^
-starts_with
-^^^^^^^^^^^
+Objects
+-------
 
-Asserts if a given value starts with a specific items.
+a
+^
+an
+^^
+type
+^^^^
+types
+^^^^^
+instance
+^^^^^^^^
+
+Asserts if a given object satisfies a type.
+You can use both a type alias string or a ``type`` object.
+
+Supported type aliases:
+
+- string
+- int
+- integer
+- number
+- object
+- float
+- bool
+- boolean
+- complex
+- list
+- dict
+- dictionary
+- tuple
+- set
+- array
+- lambda
+- generator
+- asyncgenerator
+- class
+- method
+- module
+- function
+- coroutine
+- generatorfunction
+- generator function
+- coroutinefunction
 
 =======================  ========================
- **Chained aliases**     ``by`` ``word`` ``number`` ``numbers`` ``item`` ``items`` ``value`` ``char`` ``letter`` ``character``
+ **Chained aliases**     ``type`` ``types`` ``to`` ``of``, ``equal``
 -----------------------  ------------------------
- **Related operators**   ends_with_
+ **Related operators**   equal_ matches_ implements_
 -----------------------  ------------------------
  **Optional keywords**   ``msg: str``
 =======================  ========================
@@ -909,52 +729,106 @@ Asserts if a given value starts with a specific items.
 
 .. code-block:: python
 
-    'foo' | should.start_with('f')
-    'foo' | should.start_with('fo')
-    [1, 2, 3] | should.start_with.number(1)
-    iter([1, 2, 3]) | should.start_with.numbers(1, 2)
-    OrderedDict([('foo', 0), ('bar', 1)]) | should.start_with.item('foo')
+    1 | should.be.an('int')
+    1 | should.be.an('number')
+    True | should.be.a('bool')
+    True | should.be.type(bool)
+    'foo' | should.be.a(str)
+    'foo' | should.be.a('string')
+    [1, 2, 3] | should.be.a('list')
+    [1, 2, 3] | should.have.type.of(list)
+    (1, 2, 3) | should.be.a('tuple')
+    (1, 2, 3) | should.have.type.of(tuple)
+    (lamdba x: x) | should.be.a('lambda')
+    'foo' | should.be.instance.of('string')
+    'foo' | expect.be.types('string', 'int')
 
 .. code-block:: python
 
-    'foo' | expect.to.start_with('f')
-    'foo' | expect.to.start_with('fo')
-    [1, 2, 3] | expect.to.start_with.number(1)
-    iter([1, 2, 3]) | expect.to.start_with.numbers(1, 2)
-    OrderedDict([('foo', 0), ('bar', 1)]) | expect.to.start_with('foo')
+    1 | expect.to.be.an('int')
+    1 | expect.to.be.an('number')
+    True | expect.to.be.a('bool')
+    True | expect.to.be.type(bool)
+    'foo' | expect.to.be.a(str)
+    'foo' | expect.to.be.a('string')
+    [1, 2, 3] | expect.to.be.a('list')
+    [1, 2, 3] | expect.to.have.type.of(list)
+    (1, 2, 3) | expect.to.be.a('tuple')
+    (1, 2, 3) | expect.to.have.type.of(tuple)
+    (lamdba x: x) | expect.to.be.a('lambda')
+    'foo' | expect.to.be.instance.of('string')
+    'foo' | expect.to.be.types('string', 'int')
 
 **Negation form**:
 
 .. code-block:: python
 
-    'foo' | should.do_not.start_with('o')
-    'foo' | should.do_not.start_with('o')
-    [1, 2, 3] | should.do_not.start_with(2)
-    iter([1, 2, 3]) | should.do_not.start_with.numbers(3, 4)
-    OrderedDict([('foo', 0), ('bar', 1)]) | should.start_with('bar')
+    1 | should.not_be.an('int')
+    1 | should.not_be.an('number')
+    True | should.not_be.a('bool')
+    True | should.not_be.type(bool)
+    'foo' | should.not_be.a(str)
+    'foo' | should.not_be.a('string')
+    [1, 2, 3] | should.not_be.a('list')
+    [1, 2, 3] | should.have_not.type.of(list)
+    (1, 2, 3) | should.not_be.a('tuple')
+    (1, 2, 3) | should.have_not.type.of(tuple)
+    (lamdba x: x) | should.not_be.a('lambda')
+    'foo' | should.not_to.be.instance.of('string')
+    'foo' | should.not_to.be.types('string', 'int')
 
 .. code-block:: python
 
-    'foo' | expect.to_not.start_with('f')
-    'foo' | expect.to_not.start_with('fo')
-    [1, 2, 3] | expect.to_not.start_with.number(1)
-    iter([1, 2, 3]) | expect.to_not.start_with.numbers(1, 2)
-    OrderedDict([('foo', 0), ('bar', 1)]) | expect.to_not.start_with('foo')
+    1 | expect.to_not.be.an('int')
+    1 | expect.to_not.be.an('number')
+    True | expect.to_not.be.a('bool')
+    True | expect.to_not.be.type(bool)
+    'foo' | expect.to_not.be.a(str)
+    'foo' | expect.to_not.be.a('string')
+    [1, 2, 3] | expect.to_not.be.a('list')
+    [1, 2, 3] | expect.to_not.have.type.of(list)
+    (1, 2, 3) | expect.to_not.be.a('tuple')
+    (1, 2, 3) | expect.to_not.have.type.of(tuple)
+    (lamdba x: x) | expect.to_not.be.a('lambda')
+    'foo' | expect.to.not_to.be.instance.of('string')
+    'foo' | expect.to.not_to.be.types('string', 'int')
 
 
-end_with
-^^^^^^^^
-endswith
-^^^^^^^^
-ends_with
+property
+^^^^^^^^^
+properties
+^^^^^^^^^^
+attribute
+^^^^^^^^^
+attributes
+^^^^^^^^^^
+
+Asserts if a given object has property or properties.
+
+=======================  ========================
+ **Chained aliases**     ``present`` ``equal`` ``to``
+-----------------------  ------------------------
+ **Related operators**   matches_
+-----------------------  ------------------------
+ **Yields subject**      The attribute value, if present.
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+
+implements
+^^^^^^^^^^
+implement
+^^^^^^^^^
+interface
 ^^^^^^^^^
 
-Asserts if a given value ends with a specific items.
+Asserts if a given object implements an interface of methods.
 
 =======================  ========================
- **Chained aliases**     ``by`` ``word`` ``number`` ``numbers`` ``item`` ``items`` ``value`` ``char`` ``letter`` ``character``
+ **Chained aliases**     ``interface`` ``method`` ``methods``
 -----------------------  ------------------------
- **Related operators**   ends_with_
+ **Related operators**   matches_
 -----------------------  ------------------------
  **Optional keywords**   ``msg: str``
 =======================  ========================
@@ -963,34 +837,156 @@ Asserts if a given value ends with a specific items.
 
 .. code-block:: python
 
-    'foo' | should.ends_with('o')
-    'foo' | should.ends_with('oo')
-    [1, 2, 3] | should.ends_with.number(3)
-    iter([1, 2, 3]) | should.ends_with.numbers(2, 3)
-    OrderedDict([('foo', 0), ('bar', 1)]) | should.ends_with.item('bar')
+    Foo() | should.implements('bar')
+    Foo() | should.implements.method('bar')
+    Foo() | should.implement.methods('bar', 'baz')
+    Foo() | should.implement.interface('bar', 'baz')
+    Foo() | should.satisfies.interface('bar', 'baz')
 
 .. code-block:: python
 
-    'foo' | expect.to.ends_with('o')
-    'foo' | expect.to.ends_with('oo')
-    [1, 2, 3] | expect.to.ends_with.number(3)
-    iter([1, 2, 3]) | expect.to.ends_with.numbers(2, 3)
-    OrderedDict([('foo', 0), ('bar', 1)]) | expect.to.ends_with('bar')
+    Foo() | expect.to.implement('bar')
+    Foo() | expect.to.implement.method('bar')
+    Foo() | expect.to.implement.methods('bar', 'baz')
+    Foo() | expect.to.implement.interface('bar', 'baz')
+    Foo() | expect.to.satisfy.interface('bar', 'baz')
 
 **Negation form**:
 
 .. code-block:: python
 
-    'foo' | should.do_not.ends_with('f')
-    'foo' | should.do_not.ends_with('o')
-    [1, 2, 3] | should.do_not.ends_with(2)
-    iter([1, 2, 3]) | should.do_not.ends_with.numbers(3, 4)
-    OrderedDict([('foo', 0), ('bar', 1)]) | should.ends_with('foo')
+    Foo() | should.do_not.implements('bar')
+    Foo() | should.do_not.implement.methods('bar', 'baz')
+    Foo() | should.do_not.implement.interface('bar', 'baz')
+    Foo() | should.do_not.satisfy.interface('bar', 'baz')
 
 .. code-block:: python
 
-    'foo' | expect.to_not.ends_with('f')
-    'foo' | expect.to_not.ends_with('oo')
-    [1, 2, 3] | expect.to_not.ends_with.number(2)
-    iter([1, 2, 3]) | expect.to_not.ends_with.numbers(1, 2)
-    OrderedDict([('foo', 0), ('bar', 1)]) | expect.to_not.ends_with('foo')
+    Foo() | expect.to_not.implement('bar')
+    Foo() | expect.to_not.implement.method('bar')
+    Foo() | expect.to_not.implement.methods('bar', 'baz')
+    Foo() | expect.to_not.implement.interface('bar', 'baz')
+    Foo() | expect.to_not.satisfy.interface('bar', 'baz')
+
+**Assertion form**:
+
+.. code-block:: python
+
+    Foo() | should.have.property('bar')
+    Foo() | should.have.properties('bar', 'baz')
+    Foo() | should.have.properties.present.equal.to('bar', 'baz')
+
+.. code-block:: python
+
+    Foo() | expect.to_not.have.property('bar')
+    Foo() | expect.to_not.have.properties('bar', 'baz')
+    Foo() | expect.to_not.have.properties.present.equal.to('bar', 'baz')
+
+**Negation form**:
+
+.. code-block:: python
+
+    Foo() | should.have_not.property('bar')
+    Foo() | should.have_not.properties('bar', 'baz')
+    Foo() | should.have_not.properties.present.equal.to('bar', 'baz')
+
+.. code-block:: python
+
+    Foo() | expect.to_not.have.property('bar')
+    Foo() | expect.to_not.have.properties('bar', 'baz')
+    Foo() | expect.to_not.have.properties.present.equal.to('bar', 'baz')
+
+
+Exceptions
+----------
+
+raises
+^^^^^^
+raise_error
+^^^^^^^^^^^
+raises_errors
+^^^^^^^^^^^^^
+
+Asserts if a given function raises an exception. The function must be a zero
+arity function (no arguments). If you need to pass arguments into your function
+you can use ``functools.partial`` to create a zero arity function with your
+arguments
+
+=======================  ========================
+ **Chained aliases**     ``to`` ``that`` ``are`` ``instance`` ``of``
+-----------------------  ------------------------
+ **Related operators**   matches_
+ ----------------------  ------------------------
+ **Yields subject**      Message of the exception, if present or joined exception arguments.
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    fn | should.raise_error()
+    fn | should.raise_error(ValueError)
+    fn | should.raise_error(AttributeError, ValueError)
+
+.. code-block:: python
+
+    fn | expect.to.raise_error()
+    fn | expect.to.raise_error(ValueError)
+    fn | expect.to.raise_error(AttributeError, ValueError)
+
+**Negation form**:
+
+.. code-block:: python
+
+    fn | should.do_not.raise_error()
+    fn | should.do_not.raise_error(ValueError)
+    fn | should.do_not.raise_error(AttributeError, ValueError)
+
+.. code-block:: python
+
+    fn | expect.to_not.raise_error()
+    fn | expect.to_not.raise_error(ValueError)
+    fn | expect.to_not.raise_error(AttributeError, ValueError)
+
+
+Predicates
+----------
+
+pass_test
+^^^^^^^^^
+pass_function
+^^^^^^^^^^^^^
+
+Asserts if a given subject is valid when passed to a predicate function.
+
+=======================  ========================
+ **Chained aliases**     -
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.pass_test(lambda x: len(x) > 2)
+    [1, 2, 3] | should.pass_function(lambda x: 2 in x)
+
+.. code-block:: python
+
+    'foo' | expect.to.pass_test(lambda x: len(x) > 2)
+    [1, 2, 3] | expect.to.pass_function(lambda x: 2 in x)
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foo' | should.do_not.pass_test(lambda x: len(x) > 3)
+    [1, 2, 3] | should.do_not.pass_function(lambda x: 5 in x)
+
+.. code-block:: python
+
+    'foo' | expect.to_not.pass_test(lambda x: len(x) > 3)
+    [1, 2, 3] | expect.to_not.pass_function(lambda x: 5 in x)

--- a/docs/matchers-operators.rst
+++ b/docs/matchers-operators.rst
@@ -1,384 +1,9 @@
-Assertion Operators
-===================
+Matchers Operators
+==================
 
-.. admonition:: Beta documentation
-    :class: error
-
-    Operators documentation is still beta and might contain errors, missing information or incongruencies.
-    Please, report an issue if you notice something wrong.
-
-Operator Types
---------------
-
-``grappa`` provides three different kind of assertion operators.
-
-**Attributes**
-
-Operators that only provides DSL attributes without internal assertion logic.
-
-Example operators: to_, be_ not_be_, which_ ...
-
-**Accessors**
-
-Operators that do not accept expectation arguments but performs assertion logic.
-
-Example operators: none_, true_, false_, empty_, callable_ ...
-
-**Matchers**
-
-Operators that does accept expectation arguments and therefore are callable.
+These operators does accept expectation arguments and therefore are callable.
 
 Example operators: equal_, within_, start_with_, match_, type_ ...
-
-Attributes
-----------
-
-be
-^^
-
-to
-^^
-
-has
-^^^
-
-have
-^^^^
-
-do
-^^
-
-include
-^^^^^^^
-
-satisfy
-^^^^^^^
-
-satisfies
-^^^^^^^^^
-
-_is
-^^^
-
-which
-^^^^^
-
-that
-^^^^
-
-that_is
-^^^^^^^
-
-which_is
-^^^^^^^^
-
-Semantic chainable attributes that defines non-negative assertions.
-
-Typically, you will use them implicitly in order to semantically describe your assertions.
-
-=======================  ========================
- **Type**                attribute
------------------------  ------------------------
- **Assertion mode**      positive
------------------------  ------------------------
- **Resets context**      no
-=======================  ========================
-
-**Examples**:
-
-.. code-block:: python
-
-    'foo' | should.be.equal.to('bar')
-    'foo' | should.have.length.of(3)
-
-    {'foo': 'bar'} | should.have.key('foo').which.should.be.equal.to('bar')
-    {'foo': 'bar'} | should.have.key('foo').that.should.have.length.of(3)
-
-.. code-block:: python
-
-    'foo' | expect.to.equal.to('bar')
-    'foo' | expect.to.have.length.of(3)
-
-    {'foo': 'bar'} | expect.to.have.key('foo').which.expect.to.be.equal('bar')
-    {'foo': 'bar'} | expect.to.have.key('foo').which.expect.to.have.length.of(3)
-
-
-not_be
-^^^^^^
-
-not_present
-^^^^^^^^^^^
-
-not_to
-^^^^^^
-
-to_not
-^^^^^^
-
-does_not
-^^^^^^^^
-
-do_not
-^^^^^^
-
-dont
-^^^^
-
-have_not
-^^^^^^^^
-
-not_have
-^^^^^^^^
-
-has_not
-^^^^^^^
-
-not_has
-^^^^^^^
-
-that_not
-^^^^^^^^
-
-which_not
-^^^^^^^^^
-
-is_not
-^^^^^^
-
-_not
-^^^^
-
-not_satisfy
-^^^^^^^^^^^
-
-Semantic chainable attributes that defines negative assertions.
-
-Typically, you will use them implicitly in order to semantically describe your assertions.
-
-=======================  ========================
- **Type**                attribute
------------------------  ------------------------
- **Assertion mode**      negation
------------------------  ------------------------
- **Resets context**      no
-=======================  ========================
-
-**Examples**:
-
-.. code-block:: python
-
-    'foo' | should.not_be.equal.to('bar')
-    'foo' | should.have_not.length.of(3)
-
-.. code-block:: python
-
-    'foo' | expect.to_not.equal.to('bar')
-    'foo' | expect.to.not_have.length.of(3)
-
-
-Accessors
----------
-
-true
-^^^^
-
-Asserts if a given subject is `True` value.
-
-=======================  ========================
- **Type**                accessor
------------------------  ------------------------
- **Related operators**   false_
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'foo' | should.be.true
-
-.. code-block:: python
-
-    'foo' | expect.to.be.true
-
-**Negation form**:
-
-.. code-block:: python
-
-    'foo' | should.not_be.true
-
-.. code-block:: python
-
-    'foo' | expect.to_not.be.true
-
-
-false
-^^^^^
-
-Asserts if a given subject is `False` value.
-
-=======================  ========================
- **Type**                accessor
------------------------  ------------------------
- **Related operators**   true_
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'foo' | should.be.false
-
-.. code-block:: python
-
-    'foo' | expect.to.be.false
-
-**Negation form**:
-
-.. code-block:: python
-
-    'foo' | should.not_be.false
-
-.. code-block:: python
-
-    'foo' | expect.to_not.be.false
-
-
-callable
-^^^^^^^^
-
-Asserts if a given subject is a callable type or an object that
-implements ``__call__()`` magic method.
-
-=======================  ========================
- **Type**                accessor
------------------------  ------------------------
- **Related operators**   implements_
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    (lambda x: x) | should.be.callable
-
-.. code-block:: python
-
-    (lambda x: x) | expect.to.be.callable
-
-**Negation form**:
-
-.. code-block:: python
-
-    None | should.not_be.callable
-
-.. code-block:: python
-
-    None | expect.to_not.be.callable
-
-
-empty
-^^^^^
-
-Asserts if a given subject is an empty object.
-
-A subject is considered empty if it's ``None``, ``0`` or ``len(subject)``
-is equals to ``0``.
-
-=======================  ========================
- **Type**                accessor
------------------------  ------------------------
- **Related operators**   present_ none_
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    [] | should.be.empty
-
-.. code-block:: python
-
-    tuple() | expect.to.be.empty
-
-**Negation form**:
-
-.. code-block:: python
-
-    [1, 2, 3] | should.not_be.empty
-
-.. code-block:: python
-
-    (1, 2, 3) | expect.to_not.be.empty
-
-
-none
-^^^^
-
-Asserts if a given subject is ``None``.
-
-=======================  ========================
- **Type**                accessor
------------------------  ------------------------
- **Related operators**   present_ empty_
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    None | should.be.none
-
-.. code-block:: python
-
-    None | expect.to.be.none
-
-**Negation form**:
-
-.. code-block:: python
-
-    'foo' | should.not_be.none
-
-.. code-block:: python
-
-    'foo' | expect.to_not.be.none
-
-
-exists
-^^^^^^
-
-present
-^^^^^^^
-
-Asserts if a given subject is not ``None`` or a negative value
-if evaluated via logical unary operator.
-
-This operator is the opposite of empty_.
-
-=======================  ========================
- **Type**                accessor
------------------------  ------------------------
- **Related operators**   none_ empty_
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'foo' | should.be.present
-
-.. code-block:: python
-
-    'foo' | expect.to.be.present
-
-**Negation form**:
-
-.. code-block:: python
-
-    '' | should.not_be.present
-
-.. code-block:: python
-
-    False | expect.to_not.be.present
 
 Matchers
 --------
@@ -394,8 +19,6 @@ Performs a strict equality comparison between ``x`` and ``y`` values.
 Uses ``==`` built-in binary operator for the comparison.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``value`` ``to`` ``of`` ``as`` ``data``
 -----------------------  ------------------------
  **Related operators**   contain_
@@ -431,18 +54,286 @@ Uses ``==`` built-in binary operator for the comparison.
     'foo' | expect.to_not.equal.to('foo')
     'foo' | expect.to_not.equal.to.value('foo')
 
-a
-^
 
-an
-^^
+contain
+^^^^^^^
 
-type
+contains
+^^^^^^^^
+
+includes
+^^^^^^^^
+
+Asserts if a given value or values can be found in a another object.
+
+=======================  ========================
+ **Chained aliases**     ``value`` ``string`` ``text`` ``item`` ``expression`` ``data``
+-----------------------  ------------------------
+ **Related operators**   equal_ matches_
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo bar' | should.contain('bar')
+    ['foo', 'bar'] | should.contain('bar')
+    ['foo', 'bar'] | should.contain('foo', 'bar')
+    [{'foo': True}, 'bar'] | should.contain({'foo': True})
+
+.. code-block:: python
+
+    'foo bar' | expect.to.contain('bar')
+    ['foo', 'bar'] | expect.to.contain('bar')
+    ['foo', 'bar'] | expect.to.contain('foo', 'bar')
+    [{'foo': True}, 'bar'] | expect.to.contain({'foo': True})
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foo bar' | should.do_not.contain('bar')
+    ['foo', 'bar'] | should.do_not.contain('baz')
+
+.. code-block:: python
+
+    'foo bar' | expect.to_not.contain('bar')
+    ['foo', 'bar'] | expect.to_not.contain('baz')
+
+
+key
+^^^
+
+keys
 ^^^^
 
-types
+Asserts that a given dictionary has a key or keys.
+
+=======================  ========================
+ **Chained aliases**     ``present`` ``equal`` ``to``
+-----------------------  ------------------------
+ **Related operators**   matches_ index_
+-----------------------  ------------------------
+ **Yields subject**      The key value, if present.
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    {'foo': True} | should.have.key('foo')
+    {'foo': True, 'bar': False} | should.have.keys('bar', 'foo')
+
+.. code-block:: python
+
+    {'foo': True} | expect.to.have.key('foo')
+    {'foo': True, 'bar': False} | expect.to.have.keys('bar', 'foo')
+
+**Negation form**:
+
+.. code-block:: python
+
+    {'bar': True} | should.not_have.key('foo')
+    {'baz': True, 'bar': False} | should.not_have.keys('bar', 'foo')
+
+.. code-block:: python
+
+    {'bar': True} | expect.to_not.have.key('foo')
+    {'baz': True, 'bar': False} | expect.to_not.have.keys('bar', 'foo')
+
+
+index
 ^^^^^
 
+Asserts that a given iterable has an item in a specific index.
+
+=======================  ========================
+ **Chained aliases**     ``present`` ``exists`` ``at``
+-----------------------  ------------------------
+ **Related operators**   property_ key_ contain_
+-----------------------  ------------------------
+ **Yields subject**      Value at the selected index, if present.
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    [1, 2, 3] | should.have.index(2)
+    [1, 2, 3] | should.have.index(1)
+    [1, 2, 3] | should.have.index.at(1)
+    [1, 2, 3] | should.have.index.present(1)
+    [1, 2, 3] | should.have.index.at(1).equal.to(2)
+    [1, 2, 3] | should.have.index.at(1) > should.be.equal.to(2)
+
+.. code-block:: python
+
+    [1, 2, 3] | expect.to.have.index(2)
+    [1, 2, 3] | expect.to.have.index.at(1)
+    [1, 2, 3] | expect.to.have.index.at(1).equal.to(2)
+    [1, 2, 3] | expect.to.have.index.at(1) > expect.be.equal.to(2)
+
+**Negation form**:
+
+.. code-block:: python
+
+    [1, 2, 3] | should.not_have.index(4)
+    [1, 2, 3] | should.not_have.index.at(4)
+    [1, 2, 3] | should.not_have.index.at(1).to_not.equal.to(5)
+
+.. code-block:: python
+
+    [1, 2, 3] | expect.to_not.have.index(2)
+    [1, 2, 3] | expect.to_not.have.index.at(1)
+    [1, 2, 3] | expect.to_not.have.index.at(1).equal.to(2)
+
+length
+^^^^^^
+
+size
+^^^^
+
+Asserts that a given object has exact length.
+
+=======================  ========================
+ **Chained aliases**     ``of`` ``equal`` ``to``
+-----------------------  ------------------------
+ **Related operators**   matches_
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.have.length(3)
+    [1, 2, 3] | should.have.length.of(3)
+    iter([1, 2, 3]) | should.have.length.equal.to(3)
+
+.. code-block:: python
+
+    'foo' | expect.to.have.length(3)
+    [1, 2, 3] | expect.to.have.length.of(3)
+    iter([1, 2, 3]) | expect.to.have.length.equal.to(3)
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foobar' | should.not_have.length(3)
+    [1, 2, 3, 4] | should.not_have.length.of(3)
+    iter([1, 2, 3, 4]) | should.not_have.length.equal.to(3)
+
+.. code-block:: python
+
+    'foobar' | expect.to_not.have.length(3)
+    [1, 2, 3, 4] | expect.to_not.have.length.of(3)
+    iter([1, 2, 3, 4]) | expect.to_not.have.length.equal.to(3)
+
+
+match
+^^^^^
+
+matches
+^^^^^^^
+
+Asserts if a given string matches a given regular expression.
+
+=======================  ========================
+ **Chained aliases**     ``value`` ``string`` ``expression``, ``token``, ``to``, ``regex``, ``regexp``, ``word``, ``phrase``
+-----------------------  ------------------------
+ **Related operators**   matches_
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'hello world' | should.match(r'Hello \w+')
+    'hello world' | should.match(r'hello [A-Z]+', re.I))
+    'hello world' | should.match.expression(r'hello [A-Z]+', re.I))
+
+.. code-block:: python
+
+    'hello world' | expect.to.match(r'Hello \w+')
+    'hello world' | expect.to.match(r'hello [A-Z]+', re.I))
+    'hello world' | expect.to.match.expression(r'hello [A-Z]+', re.I))
+
+**Negation form**:
+
+.. code-block:: python
+
+    'hello w0rld' | should.do_not.match(r'Hello \w+')
+    'hello w0rld' | should.do_not.match(r'hello [A-Z]+', re.I))
+    'hello world' | should.do_not.match.expression(r'hello [A-Z]+', re.I))
+
+.. code-block:: python
+
+    'hello w0rld' | expect.to_not.match(r'Hello \w+')
+    'hello w0rld' | expect.to_not.match(r'hello [A-Z]+', re.I))
+    'hello world' | expect.to_not.match.expression(r'hello [A-Z]+', re.I))
+
+pass_test
+^^^^^^^^^
+
+pass_function
+^^^^^^^^^^^^^
+
+Asserts if a given string matches a given regular expression.
+
+=======================  ========================
+ **Chained aliases**     -
+-----------------------  ------------------------
+ **Related operators**   matches_
+-----------------------  ------------------------
+ **Optional keywords**   ``msg: str``
+=======================  ========================
+
+**Assertion form**:
+
+.. code-block:: python
+
+    'foo' | should.pass_test(lambda x: len(x) > 2)
+    [1, 2, 3] | should.pass_function(lambda x: 2 in x)
+
+.. code-block:: python
+
+    'foo' | expect.to.pass_test(lambda x: len(x) > 2)
+    [1, 2, 3] | expect.to.pass_function(lambda x: 2 in x)
+
+**Negation form**:
+
+.. code-block:: python
+
+    'foo' | should.do_not.pass_test(lambda x: len(x) > 3)
+    [1, 2, 3] | should.do_not.pass_function(lambda x: 5 in x)
+
+.. code-block:: python
+
+    'foo' | expect.to_not.pass_test(lambda x: len(x) > 3)
+    [1, 2, 3] | expect.to_not.pass_function(lambda x: 5 in x)
+
+
+Objects
+-------
+
+a
+^
+an
+^^
+type
+^^^^
+types
+^^^^^
 instance
 ^^^^^^^^
 
@@ -479,8 +370,6 @@ Supported type aliases:
 - coroutinefunction
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``type`` ``types`` ``to`` ``of``, ``equal``
 -----------------------  ------------------------
  **Related operators**   equal_ matches_ implements_
@@ -557,70 +446,38 @@ Supported type aliases:
     'foo' | expect.to.not_to.be.types('string', 'int')
 
 
-contain
-^^^^^^^
+property
+^^^^^^^^^
+properties
+^^^^^^^^^^
+attribute
+^^^^^^^^^
+attributes
+^^^^^^^^^^
 
-contains
-^^^^^^^^
-
-includes
-^^^^^^^^
-
-Asserts if a given value or values can be found in a another object.
+Asserts if a given object has property or properties.
 
 =======================  ========================
- **Type**                matcher
+ **Chained aliases**     ``present`` ``equal`` ``to``
 -----------------------  ------------------------
- **Chained aliases**     ``value`` ``string`` ``text`` ``item`` ``expression`` ``data``
+ **Related operators**   matches_
 -----------------------  ------------------------
- **Related operators**   equal_ matches_
+ **Yields subject**      The attribute value, if present.
 -----------------------  ------------------------
  **Optional keywords**   ``msg: str``
 =======================  ========================
 
-**Assertion form**:
-
-.. code-block:: python
-
-    'foo bar' | should.contain('bar')
-    ['foo', 'bar'] | should.contain('bar')
-    ['foo', 'bar'] | should.contain('foo', 'bar')
-    [{'foo': True}, 'bar'] | should.contain({'foo': True})
-
-.. code-block:: python
-
-    'foo bar' | expect.to.contain('bar')
-    ['foo', 'bar'] | expect.to.contain('bar')
-    ['foo', 'bar'] | expect.to.contain('foo', 'bar')
-    [{'foo': True}, 'bar'] | expect.to.contain({'foo': True})
-
-**Negation form**:
-
-.. code-block:: python
-
-    'foo bar' | should.do_not.contain('bar')
-    ['foo', 'bar'] | should.do_not.contain('baz')
-
-.. code-block:: python
-
-    'foo bar' | expect.to_not.contain('bar')
-    ['foo', 'bar'] | expect.to_not.contain('baz')
-
 
 implements
 ^^^^^^^^^^
-
 implement
 ^^^^^^^^^
-
 interface
 ^^^^^^^^^
 
 Asserts if a given object implements an interface of methods.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``interface`` ``method`` ``methods``
 -----------------------  ------------------------
  **Related operators**   matches_
@@ -663,263 +520,6 @@ Asserts if a given object implements an interface of methods.
     Foo() | expect.to_not.implement.interface('bar', 'baz')
     Foo() | expect.to_not.satisfy.interface('bar', 'baz')
 
-
-key
-^^^
-
-keys
-^^^^
-
-Asserts that a given dictionary has a key or keys.
-
-=======================  ========================
- **Type**                matcher
------------------------  ------------------------
- **Chained aliases**     ``present`` ``equal`` ``to``
------------------------  ------------------------
- **Related operators**   matches_ index_
------------------------  ------------------------
- **Yields subject**      The key value, if present.
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    {'foo': True} | should.have.key('foo')
-    {'foo': True, 'bar': False} | should.have.keys('bar', 'foo')
-
-.. code-block:: python
-
-    {'foo': True} | expect.to.have.key('foo')
-    {'foo': True, 'bar': False} | expect.to.have.keys('bar', 'foo')
-
-**Negation form**:
-
-.. code-block:: python
-
-    {'bar': True} | should.not_have.key('foo')
-    {'baz': True, 'bar': False} | should.not_have.keys('bar', 'foo')
-
-.. code-block:: python
-
-    {'bar': True} | expect.to_not.have.key('foo')
-    {'baz': True, 'bar': False} | expect.to_not.have.keys('bar', 'foo')
-
-
-index
-^^^^^
-
-Asserts that a given iterable has an item in a specific index.
-
-=======================  ========================
- **Type**                matcher
------------------------  ------------------------
- **Chained aliases**     ``present`` ``exists`` ``at``
------------------------  ------------------------
- **Related operators**   property_ key_ contain_
------------------------  ------------------------
- **Yields subject**      Value at the selected index, if present.
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    [1, 2, 3] | should.have.index(2)
-    [1, 2, 3] | should.have.index(1)
-    [1, 2, 3] | should.have.index.at(1)
-    [1, 2, 3] | should.have.index.present(1)
-    [1, 2, 3] | should.have.index.at(1).equal.to(2)
-    [1, 2, 3] | should.have.index.at(1) > should.be.equal.to(2)
-
-.. code-block:: python
-
-    [1, 2, 3] | expect.to.have.index(2)
-    [1, 2, 3] | expect.to.have.index.at(1)
-    [1, 2, 3] | expect.to.have.index.at(1).equal.to(2)
-    [1, 2, 3] | expect.to.have.index.at(1) > expect.be.equal.to(2)
-
-**Negation form**:
-
-.. code-block:: python
-
-    [1, 2, 3] | should.not_have.index(4)
-    [1, 2, 3] | should.not_have.index.at(4)
-    [1, 2, 3] | should.not_have.index.at(1).to_not.equal.to(5)
-
-.. code-block:: python
-
-    [1, 2, 3] | expect.to_not.have.index(2)
-    [1, 2, 3] | expect.to_not.have.index.at(1)
-    [1, 2, 3] | expect.to_not.have.index.at(1).equal.to(2)
-
-length
-^^^^^^
-
-size
-^^^^
-
-Asserts that a given object has exact length.
-
-=======================  ========================
- **Type**                matcher
------------------------  ------------------------
- **Chained aliases**     ``of`` ``equal`` ``to``
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'foo' | should.have.length(3)
-    [1, 2, 3] | should.have.length.of(3)
-    iter([1, 2, 3]) | should.have.length.equal.to(3)
-
-.. code-block:: python
-
-    'foo' | expect.to.have.length(3)
-    [1, 2, 3] | expect.to.have.length.of(3)
-    iter([1, 2, 3]) | expect.to.have.length.equal.to(3)
-
-**Negation form**:
-
-.. code-block:: python
-
-    'foobar' | should.not_have.length(3)
-    [1, 2, 3, 4] | should.not_have.length.of(3)
-    iter([1, 2, 3, 4]) | should.not_have.length.equal.to(3)
-
-.. code-block:: python
-
-    'foobar' | expect.to_not.have.length(3)
-    [1, 2, 3, 4] | expect.to_not.have.length.of(3)
-    iter([1, 2, 3, 4]) | expect.to_not.have.length.equal.to(3)
-
-
-match
-^^^^^
-
-matches
-^^^^^^^
-
-Asserts if a given string matches a given regular expression.
-
-=======================  ========================
- **Type**                matcher
------------------------  ------------------------
- **Chained aliases**     ``value`` ``string`` ``expression``, ``token``, ``to``, ``regex``, ``regexp``, ``word``, ``phrase``
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'hello world' | should.match(r'Hello \w+')
-    'hello world' | should.match(r'hello [A-Z]+', re.I))
-    'hello world' | should.match.expression(r'hello [A-Z]+', re.I))
-
-.. code-block:: python
-
-    'hello world' | expect.to.match(r'Hello \w+')
-    'hello world' | expect.to.match(r'hello [A-Z]+', re.I))
-    'hello world' | expect.to.match.expression(r'hello [A-Z]+', re.I))
-
-**Negation form**:
-
-.. code-block:: python
-
-    'hello w0rld' | should.do_not.match(r'Hello \w+')
-    'hello w0rld' | should.do_not.match(r'hello [A-Z]+', re.I))
-    'hello world' | should.do_not.match.expression(r'hello [A-Z]+', re.I))
-
-.. code-block:: python
-
-    'hello w0rld' | expect.to_not.match(r'Hello \w+')
-    'hello w0rld' | expect.to_not.match(r'hello [A-Z]+', re.I))
-    'hello world' | expect.to_not.match.expression(r'hello [A-Z]+', re.I))
-
-pass_test
-^^^^^^^^^
-
-pass_function
-^^^^^^^^^^^^^
-
-Asserts if a given string matches a given regular expression.
-
-=======================  ========================
- **Type**                matcher
------------------------  ------------------------
- **Chained aliases**     -
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
-**Assertion form**:
-
-.. code-block:: python
-
-    'foo' | should.pass_test(lambda x: len(x) > 2)
-    [1, 2, 3] | should.pass_function(lambda x: 2 in x)
-
-.. code-block:: python
-
-    'foo' | expect.to.pass_test(lambda x: len(x) > 2)
-    [1, 2, 3] | expect.to.pass_function(lambda x: 2 in x)
-
-**Negation form**:
-
-.. code-block:: python
-
-    'foo' | should.do_not.pass_test(lambda x: len(x) > 3)
-    [1, 2, 3] | should.do_not.pass_function(lambda x: 5 in x)
-
-.. code-block:: python
-
-    'foo' | expect.to_not.pass_test(lambda x: len(x) > 3)
-    [1, 2, 3] | expect.to_not.pass_function(lambda x: 5 in x)
-
-
-property
-^^^^^^^^^
-
-properties
-^^^^^^^^^^
-
-attribute
-^^^^^^^^^
-
-attributes
-^^^^^^^^^^
-
-Asserts if a given object has property or properties.
-
-=======================  ========================
- **Type**                matcher
------------------------  ------------------------
- **Chained aliases**     ``present`` ``equal`` ``to``
------------------------  ------------------------
- **Related operators**   matches_
------------------------  ------------------------
- **Yields subject**      The attribute value, if present.
------------------------  ------------------------
- **Optional keywords**   ``msg: str``
-=======================  ========================
-
 **Assertion form**:
 
 .. code-block:: python
@@ -949,12 +549,13 @@ Asserts if a given object has property or properties.
     Foo() | expect.to_not.have.properties.present.equal.to('bar', 'baz')
 
 
+Exceptions
+----------
+
 raises
 ^^^^^^
-
 raise_error
 ^^^^^^^^^^^
-
 raises_errors
 ^^^^^^^^^^^^^
 
@@ -964,8 +565,6 @@ you can use ``functools.partial`` to create a zero arity function with your
 arguments
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``to`` ``that`` ``are`` ``instance`` ``of``
 -----------------------  ------------------------
  **Related operators**   matches_
@@ -1002,20 +601,19 @@ arguments
     fn | expect.to_not.raise_error(AttributeError, ValueError)
 
 
+Numbers
+-------
+
 below
 ^^^^^
-
 lower
 ^^^^^
-
 less
 ^^^^
 
 Asserts if a given number is below to another number.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``of`` ``to`` ``than`` ``number``
 -----------------------  ------------------------
  **Related operators**   within_ above_ above_or_equal_ below_or_equal_
@@ -1066,15 +664,12 @@ Asserts if a given number is below to another number.
 
 above
 ^^^^^
-
 higher
 ^^^^^^
 
 Asserts if a given number is above to another number.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``of`` ``to`` ``than`` ``number``
 -----------------------  ------------------------
  **Related operators**   within_ below_ below_or_equal_ above_or_equal_
@@ -1125,18 +720,14 @@ Asserts if a given number is above to another number.
 
 least
 ^^^^^
-
 above_or_equal
 ^^^^^^^^^^^^^^
-
 higher_or_equal
 ^^^^^^^^^^^^^^^
 
 Asserts if a given number is above to another number.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``of`` ``to`` ``than`` ``number``
 -----------------------  ------------------------
  **Related operators**   within_ below_ below_or_equal_ above_or_equal_
@@ -1191,18 +782,14 @@ Asserts if a given number is above to another number.
 
 most
 ^^^^
-
 below_or_equal
 ^^^^^^^^^^^^^^
-
 lower_or_equal
 ^^^^^^^^^^^^^^^
 
 Asserts if a given number is above to another number.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``of`` ``to`` ``than`` ``number``
 -----------------------  ------------------------
  **Related operators**   within_ below_ above_ below_or_equal_ above_or_equal_
@@ -1257,15 +844,12 @@ Asserts if a given number is above to another number.
 
 within
 ^^^^^^
-
 between
 ^^^^^^^
 
 Asserts that a number is within a range.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``to`` ``numbers`` ``range``
 -----------------------  ------------------------
  **Related operators**   below_ above_ above_or_equal_ below_or_equal_
@@ -1301,20 +885,19 @@ Asserts that a number is within a range.
     5 | expect.to_not.be.between(2, 5)
     4.5 | expect.to_not.be.within(4, 5)
 
+Ranges
+------
+
 start_with
 ^^^^^^^^^^
-
 startswith
 ^^^^^^^^^^
-
 starts_with
 ^^^^^^^^^^^
 
 Asserts if a given value starts with a specific items.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``by`` ``word`` ``number`` ``numbers`` ``item`` ``items`` ``value`` ``char`` ``letter`` ``character``
 -----------------------  ------------------------
  **Related operators**   ends_with_
@@ -1361,18 +944,14 @@ Asserts if a given value starts with a specific items.
 
 end_with
 ^^^^^^^^
-
 endswith
 ^^^^^^^^
-
 ends_with
 ^^^^^^^^^
 
 Asserts if a given value ends with a specific items.
 
 =======================  ========================
- **Type**                matcher
------------------------  ------------------------
  **Chained aliases**     ``by`` ``word`` ``number`` ``numbers`` ``item`` ``items`` ``value`` ``char`` ``letter`` ``character``
 -----------------------  ------------------------
  **Related operators**   ends_with_

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -6,3 +6,4 @@ References
 - **chai.js** - http://chaijs.com
 - **should.js** - https://shouldjs.github.io
 - **RSpec** - http://rspec.info
+- **Jasmine** - https://jasmine.github.io/

--- a/docs/style.rst
+++ b/docs/style.rst
@@ -33,6 +33,22 @@ however it extends each object with a should property to start your chain.
     should('foo').have.length.of(3)
     should(beverages).have.property('tea').with.length.of(3)
 
+
+.. tip::
+
+    For this assertion style, accessors and matchers operators will raise ``pylint``
+    warnings that can be disabled with these comments.
+
+    To ignore rules for the whole module place them before ``import`` statements.
+
+    .. code-block:: python
+
+        True | should.be.true  # pylint: disable=W0104
+        True | should.be.true  # pylint: disable=pointless-statement
+
+        True | should.equal(True)  # pylint: disable=W0106
+        True | should.equal(True)  # pylint: disable=expression-not-assigned
+
 expect
 ------
 
@@ -52,3 +68,17 @@ expect
     expect(foo).to.equal('bar')
     expect(foo).to.have.length.of(3)
     expect(beverages).to.have.property('tea').that.has.length.of(3)
+
+
+.. tip::
+
+    For this assertion style, accessors operators will raise ``pylint``
+    warnings that can be disabled with these comments.
+
+    To ignore rules for the whole module place them before ``import`` statements.
+
+    .. code-block:: python
+
+        expect(True).to.be.true  # pylint: disable=W0106
+        expect(True).to.be.true  # pylint: disable=expression-not-assigned
+

--- a/docs/style.rst
+++ b/docs/style.rst
@@ -28,10 +28,17 @@ however it extends each object with a should property to start your chain.
     foo | should.have.length.of(3)
     beverages | should.have.property('tea').with.length.of(3)
 
-    should(foo).be.a('string')
-    should('foo').to.be.equal('foo')
-    should('foo').have.length.of(3)
-    should(beverages).have.property('tea').with.length.of(3)
+
+.. note::
+
+    ``should`` can be used as a function like how the ``expect`` verb is usually used.
+
+    .. code-block:: python
+
+        should(foo).be.a('string')
+        should('foo').to.be.equal('foo')
+        should('foo').have.length.of(3)
+        should(beverages).have.property('tea').with.length.of(3)
 
 
 .. tip::
@@ -59,15 +66,22 @@ expect
     foo = 'bar'
     beverages = { 'tea': [ 'grappa', 'matcha', 'long' ] }
 
-    foo | expect.to.be.a('string')
-    foo | expect.to.equal('bar')
-    foo | expect.to.have.length.of(3)
-    beverages | expect.to.have.property('tea').that.has.length.of(3)
-
     expect(foo).to.be.a('string')
     expect(foo).to.equal('bar')
     expect(foo).to.have.length.of(3)
     expect(beverages).to.have.property('tea').that.has.length.of(3)
+
+
+.. note::
+
+    ``expect`` can be used with piping operator like how the ``should`` verb is usually used.
+
+    .. code-block:: python
+
+        foo | expect.to.be.a('string')
+        foo | expect.to.equal('bar')
+        foo | expect.to.have.length.of(3)
+        beverages | expect.to.have.property('tea').that.has.length.of(3)
 
 
 .. tip::


### PR DESCRIPTION
Operator page splitted in 3 pages: Attributes, Accessors and Matchers.
Section/Subsection reorganization in Matchers.
README simplified a bit.

Renamed
- **Tutorial** to **Getting started**
- **Errors** to **Error reporting**